### PR TITLE
Update OpenAPI spec: add Stripe to customer externalIntegration enum

### DIFF
--- a/config/vy-openapi.yml
+++ b/config/vy-openapi.yml
@@ -734,6 +734,12 @@ components:
         description:
           type: string
           description: The description of the catalog product
+        productCode:
+          type: string
+          description: The product code of the catalog product
+        disableDescription:
+          type: boolean
+          description: Whether to disable the default description on generated line items
         externalId:
           type: string
           description: The external ID of the catalog product
@@ -752,6 +758,12 @@ components:
             description:
               type: string
               description: The description of the catalog product
+            productCode:
+              type: string
+              description: The product code of the catalog product
+            disableDescription:
+              type: boolean
+              description: Whether to disable the default description on generated line items
             externalId:
               type: string
               description: The external ID of the catalog product
@@ -785,6 +797,12 @@ components:
               description:
                 type: string
                 description: The description of the catalog product
+              productCode:
+                type: string
+                description: The product code of the catalog product
+              disableDescription:
+                type: boolean
+                description: Whether to disable the default description on generated line items
               externalId:
                 type: string
                 description: The external ID of the catalog product
@@ -824,6 +842,12 @@ components:
             description:
               type: string
               description: The description of the catalog product
+            productCode:
+              type: string
+              description: The product code of the catalog product
+            disableDescription:
+              type: boolean
+              description: Whether to disable the default description on generated line items
             externalId:
               type: string
               description: The external ID of the catalog product
@@ -852,6 +876,12 @@ components:
         description:
           type: string
           description: The description of the catalog product
+        productCode:
+          type: string
+          description: The product code of the catalog product
+        disableDescription:
+          type: boolean
+          description: Whether to disable the default description on generated line items
         externalId:
           type: string
           description: The external ID of the catalog product
@@ -869,6 +899,12 @@ components:
             description:
               type: string
               description: The description of the catalog product
+            productCode:
+              type: string
+              description: The product code of the catalog product
+            disableDescription:
+              type: boolean
+              description: Whether to disable the default description on generated line items
             externalId:
               type: string
               description: The external ID of the catalog product
@@ -900,6 +936,12 @@ components:
             description:
               type: string
               description: The description of the catalog product
+            productCode:
+              type: string
+              description: The product code of the catalog product
+            disableDescription:
+              type: boolean
+              description: Whether to disable the default description on generated line items
             externalId:
               type: string
               description: The external ID of the catalog product
@@ -947,6 +989,15 @@ components:
         - HubSpot
         - ContractExtraction
       description: The source of the customer
+    CustomerStatus:
+      type: string
+      enum:
+        - Active
+        - Inactive
+        - Suspended
+        - Trial
+      description: The lifecycle status of the customer. Defaults to Active when
+        omitted on creation.
     CustomerCloudProviderSettings:
       type: object
       nullable: true
@@ -965,6 +1016,9 @@ components:
       nullable: true
       properties:
         country:
+          type: string
+          nullable: true
+        countryCode:
           type: string
           nullable: true
         city:
@@ -996,6 +1050,9 @@ components:
             - Xero
             - Salesforce
             - Paddle
+            - Stripe
+          description: The integration provider. Stripe links are saved on the customer;
+            other providers are linked via the integration registry.
         id:
           type: string
         name:
@@ -1109,6 +1166,8 @@ components:
             type: string
           default: []
           description: The tax IDs of the customer
+        status:
+          $ref: "#/components/schemas/CustomerStatus"
         taxId:
           type: string
           nullable: true
@@ -1153,6 +1212,7 @@ components:
             - 45_DAYS
             - 60_DAYS
             - 90_DAYS
+            - 180_DAYS
           description: The due days of the customer
         currency:
           $ref: "#/components/schemas/Currency"
@@ -1219,6 +1279,8 @@ components:
                 type: string
               default: []
               description: The tax IDs of the customer
+            status:
+              $ref: "#/components/schemas/CustomerStatus"
             taxId:
               type: string
               nullable: true
@@ -1263,6 +1325,7 @@ components:
                 - 45_DAYS
                 - 60_DAYS
                 - 90_DAYS
+                - 180_DAYS
               description: The due days of the customer
             currency:
               $ref: "#/components/schemas/Currency"
@@ -1344,6 +1407,8 @@ components:
                   type: string
                 default: []
                 description: The tax IDs of the customer
+              status:
+                $ref: "#/components/schemas/CustomerStatus"
               taxId:
                 type: string
                 nullable: true
@@ -1388,6 +1453,7 @@ components:
                   - 45_DAYS
                   - 60_DAYS
                   - 90_DAYS
+                  - 180_DAYS
                 description: The due days of the customer
               currency:
                 $ref: "#/components/schemas/Currency"
@@ -1475,6 +1541,8 @@ components:
                 type: string
               default: []
               description: The tax IDs of the customer
+            status:
+              $ref: "#/components/schemas/CustomerStatus"
             taxId:
               type: string
               nullable: true
@@ -1519,6 +1587,7 @@ components:
                 - 45_DAYS
                 - 60_DAYS
                 - 90_DAYS
+                - 180_DAYS
               description: The due days of the customer
             currency:
               $ref: "#/components/schemas/Currency"
@@ -1595,6 +1664,8 @@ components:
             type: string
           default: []
           description: The tax IDs of the customer
+        status:
+          $ref: "#/components/schemas/CustomerStatus"
         taxId:
           type: string
           nullable: true
@@ -1639,6 +1710,7 @@ components:
             - 45_DAYS
             - 60_DAYS
             - 90_DAYS
+            - 180_DAYS
           description: The due days of the customer
         currency:
           $ref: "#/components/schemas/Currency"
@@ -1704,6 +1776,8 @@ components:
                 type: string
               default: []
               description: The tax IDs of the customer
+            status:
+              $ref: "#/components/schemas/CustomerStatus"
             taxId:
               type: string
               nullable: true
@@ -1748,6 +1822,7 @@ components:
                 - 45_DAYS
                 - 60_DAYS
                 - 90_DAYS
+                - 180_DAYS
               description: The due days of the customer
             currency:
               $ref: "#/components/schemas/Currency"
@@ -1827,6 +1902,8 @@ components:
                 type: string
               default: []
               description: The tax IDs of the customer
+            status:
+              $ref: "#/components/schemas/CustomerStatus"
             taxId:
               type: string
               nullable: true
@@ -1871,6 +1948,7 @@ components:
                 - 45_DAYS
                 - 60_DAYS
                 - 90_DAYS
+                - 180_DAYS
               description: The due days of the customer
             currency:
               $ref: "#/components/schemas/Currency"
@@ -2015,6 +2093,9 @@ components:
               type: string
               minLength: 1
               description: The name of the event that the meter is tracking.
+            productCode:
+              type: string
+              description: The product code of the meter
             aggregationMethod:
               $ref: "#/components/schemas/AggregationMethod"
             filter:
@@ -2047,6 +2128,9 @@ components:
           type: string
           minLength: 1
           description: The name of the event that the meter is tracking.
+        productCode:
+          type: string
+          description: The product code of the meter
         aggregationMethod:
           $ref: "#/components/schemas/AggregationMethod"
         filter:
@@ -2066,6 +2150,9 @@ components:
               type: string
               minLength: 1
               description: The name of the event that the meter is tracking.
+            productCode:
+              type: string
+              description: The product code of the meter
             aggregationMethod:
               $ref: "#/components/schemas/AggregationMethod"
             filter:
@@ -2101,6 +2188,9 @@ components:
               type: string
               minLength: 1
               description: The name of the event that the meter is tracking.
+            productCode:
+              type: string
+              description: The product code of the meter
             aggregationMethod:
               $ref: "#/components/schemas/AggregationMethod"
             filter:
@@ -2141,6 +2231,9 @@ components:
                 type: string
                 minLength: 1
                 description: The name of the event that the meter is tracking.
+              productCode:
+                type: string
+                description: The product code of the meter
               aggregationMethod:
                 $ref: "#/components/schemas/AggregationMethod"
               filter:
@@ -2349,6 +2442,10 @@ components:
                 type: string
                 nullable: true
                 description: The description of the product
+              disableDescription:
+                type: boolean
+                nullable: true
+                description: Whether to disable the default description on generated line items
               scheduling:
                 type: object
                 properties:
@@ -2556,6 +2653,10 @@ components:
                         description: When true, this product is billed on its own invoice instead of
                           being combined with other products in the same
                           contract. Defaults to false.
+                      seats:
+                        type: integer
+                        minimum: 0
+                        description: The number of seats for this subscription product.
                     required:
                       - type
                       - price
@@ -2951,6 +3052,10 @@ components:
                     type: string
                     nullable: true
                     description: The description of the product
+                  disableDescription:
+                    type: boolean
+                    nullable: true
+                    description: Whether to disable the default description on generated line items
                   scheduling:
                     type: object
                     properties:
@@ -3158,6 +3263,10 @@ components:
                             description: When true, this product is billed on its own invoice instead of
                               being combined with other products in the same
                               contract. Defaults to false.
+                          seats:
+                            type: integer
+                            minimum: 0
+                            description: The number of seats for this subscription product.
                         required:
                           - type
                           - price
@@ -3534,6 +3643,10 @@ components:
                     type: string
                     nullable: true
                     description: The description of the product
+                  disableDescription:
+                    type: boolean
+                    nullable: true
+                    description: Whether to disable the default description on generated line items
                   scheduling:
                     type: object
                     properties:
@@ -3741,6 +3854,10 @@ components:
                             description: When true, this product is billed on its own invoice instead of
                               being combined with other products in the same
                               contract. Defaults to false.
+                          seats:
+                            type: integer
+                            minimum: 0
+                            description: The number of seats for this subscription product.
                         required:
                           - type
                           - price
@@ -4117,6 +4234,10 @@ components:
                 type: string
                 nullable: true
                 description: The description of the product
+              disableDescription:
+                type: boolean
+                nullable: true
+                description: Whether to disable the default description on generated line items
               scheduling:
                 type: object
                 properties:
@@ -4324,6 +4445,10 @@ components:
                         description: When true, this product is billed on its own invoice instead of
                           being combined with other products in the same
                           contract. Defaults to false.
+                      seats:
+                        type: integer
+                        minimum: 0
+                        description: The number of seats for this subscription product.
                     required:
                       - type
                       - price
@@ -4687,6 +4812,10 @@ components:
                     type: string
                     nullable: true
                     description: The description of the product
+                  disableDescription:
+                    type: boolean
+                    nullable: true
+                    description: Whether to disable the default description on generated line items
                   scheduling:
                     type: object
                     properties:
@@ -4894,6 +5023,10 @@ components:
                             description: When true, this product is billed on its own invoice instead of
                               being combined with other products in the same
                               contract. Defaults to false.
+                          seats:
+                            type: integer
+                            minimum: 0
+                            description: The number of seats for this subscription product.
                         required:
                           - type
                           - price
@@ -6381,8 +6514,16 @@ components:
           type: string
           description: The new access token to be used for subsequent API calls. It is set
             to expire every hour.
+        expiresIn:
+          type: integer
+          description: The lifetime of the access token in seconds.
+        expiresAt:
+          type: string
+          description: The expiration time of the access token, in ISO 8601 format.
       required:
         - accessToken
+        - expiresIn
+        - expiresAt
     DeleteEventsByRefsRequest:
       type: object
       properties:
@@ -6526,6 +6667,9 @@ components:
           type: string
           minLength: 1
           description: The name of the event that the meter is tracking.
+        productCode:
+          type: string
+          description: The product code of the meter
         aggregationMethod:
           $ref: "#/components/schemas/AggregationMethod"
         filter:
@@ -7528,6 +7672,7 @@ components:
         - CustomerCreated
         - ContractCreated
         - InvoiceIssueDateArrived
+        - MeteringHealthDegraded
         - PingTest
     WebhookSubscribeRequest:
       type: object
@@ -7579,6 +7724,8 @@ components:
                 type: string
               default: []
               description: The tax IDs of the customer
+            status:
+              $ref: "#/components/schemas/CustomerStatus"
             taxId:
               type: string
               nullable: true
@@ -7623,6 +7770,7 @@ components:
                 - 45_DAYS
                 - 60_DAYS
                 - 90_DAYS
+                - 180_DAYS
               description: The due days of the customer
             currency:
               $ref: "#/components/schemas/Currency"
@@ -7766,6 +7914,8 @@ components:
                 type: string
               default: []
               description: The tax IDs of the customer
+            status:
+              $ref: "#/components/schemas/CustomerStatus"
             taxId:
               type: string
               nullable: true
@@ -7810,6 +7960,7 @@ components:
                 - 45_DAYS
                 - 60_DAYS
                 - 90_DAYS
+                - 180_DAYS
               description: The due days of the customer
             currency:
               $ref: "#/components/schemas/Currency"
@@ -7901,6 +8052,10 @@ components:
                     type: string
                     nullable: true
                     description: The description of the product
+                  disableDescription:
+                    type: boolean
+                    nullable: true
+                    description: Whether to disable the default description on generated line items
                   scheduling:
                     type: object
                     properties:
@@ -8108,6 +8263,10 @@ components:
                             description: When true, this product is billed on its own invoice instead of
                               being combined with other products in the same
                               contract. Defaults to false.
+                          seats:
+                            type: integer
+                            minimum: 0
+                            description: The number of seats for this subscription product.
                         required:
                           - type
                           - price
@@ -8484,6 +8643,10 @@ components:
                       type: string
                       nullable: true
                       description: The description of the product
+                    disableDescription:
+                      type: boolean
+                      nullable: true
+                      description: Whether to disable the default description on generated line items
                     scheduling:
                       type: object
                       properties:
@@ -8691,6 +8854,10 @@ components:
                               description: When true, this product is billed on its own invoice instead of
                                 being combined with other products in the same
                                 contract. Defaults to false.
+                            seats:
+                              type: integer
+                              minimum: 0
+                              description: The number of seats for this subscription product.
                           required:
                             - type
                             - price
@@ -9666,6 +9833,11 @@ paths:
       security:
         - BearerAuthorizer: []
       parameters:
+        - schema:
+            $ref: "#/components/schemas/CustomerStatus"
+          required: false
+          in: query
+          name: status
         - schema:
             $ref: "#/components/schemas/Limit"
           required: false


### PR DESCRIPTION
## What

Replaces `config/vy-openapi.yml` with the spec regenerated from vayu `main` (post vayucode/vayu#6488).

## Why

The docs site does not show `Stripe` as a valid `externalIntegration[].type` on **Create Customer**, even though the API has supported it since ENG-7128. The generator's `oz.union([IntegrationTypesV3Schema, oz.literal(STRIPE)])` rendered only the nativeEnum into OpenAPI, silently dropping the Stripe literal. PR #6488 in the monorepo fixed the schema; this publishes the regenerated spec.

## Contents

- `CustomerExternalIntegration.type` enum now includes `Stripe` (11 values)
- Spec drift since the last publish (2026-07-21): +172 lines of endpoint/schema updates from main

🤖 Generated with [Claude Code](https://claude.com/claude-code)